### PR TITLE
[PR] Use latest Flutter in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,6 @@ jobs:
       # Installing Flutter because it's easier to generate .lcov files for test coverage
       - name: Install Flutter
         uses: subosito/flutter-action@v2
-        with:
-          flutter-version: '3.3.8'
-          channel: 'stable'
 
       - name: Install dependencies
         run: flutter pub get


### PR DESCRIPTION
uses latest `Flutter` version on CI. 

This is to try and get #15 working.